### PR TITLE
Allow changing remote vboxwebsrv path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache bash openssh-client
 ENV PORT 5678
 ENV USE_KEY 0
 ENV SSH_PORT 22
+ENV $VBOXWEBSRVPATH vboxwebsrv
 
 # only expose default vboxwebsrv port
 EXPOSE 18083

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache bash openssh-client
 ENV PORT 5678
 ENV USE_KEY 0
 ENV SSH_PORT 22
-ENV $VBOXWEBSRVPATH vboxwebsrv
+ENV VBOXWEBSRVPATH vboxwebsrv
 
 # only expose default vboxwebsrv port
 EXPOSE 18083

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Now you can point your phpVirtualBox container to the vboxwebsrv container. Plea
 
 You could also use a different SSH Port (default port is 22) by using `-e SSH_PORT=portNumber` environment variable.
 
+## Different remote vboxwebsrv path
+
+You can choose a different path for the remote vboxwebsrv by using `-e VBOXWEBSRVPATH=/path/to/vboxwebsrv` environment variable.
+
 ## Docker Compose
 
 A docker compose file could look as follows:

--- a/run.sh
+++ b/run.sh
@@ -13,4 +13,4 @@ fi
 sshHost=$(awk -F@ '{print $2}' <<<$1)
 
 ssh -p $SSH_PORT $1 "killall vboxwebsrv"
-ssh -p $SSH_PORT -L 0.0.0.0:18083:$sshHost:$PORT $1 "killall vboxwebsrv; vboxwebsrv -p $PORT -A null -H $sshHost"
+ssh -p $SSH_PORT -L 0.0.0.0:18083:$sshHost:$PORT $1 "killall vboxwebsrv; \"$VBOXWEBSRVPATH\" -p $PORT -A null -H $sshHost"


### PR DESCRIPTION
### Intention
Some VirtualBox installations don't put the virtual box binaries into the global PATH. Gentoo does this (virtualbox-bin package), and the binaries can be found in `/opt/VirtualBox`. In this case, the virtualbox websrv can't be started.

### Changes
I just added a environment variable specifying the remote path of the executable, which defaults to the global `vboxwebsrv`, so it's fully backwards-compatible. This allows a user to change the invocation target of the vboxwebsrv.