### PR TITLE
bind vboxwebserv to local host as we use it through an ssh tunnel anyway

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ if [ "$USE_KEY" != "0" ] && [ ! -f ~/.ssh/id_rsa ]; then
     read -p "Press [Enter] to contiue..."
 fi
 
-sshHost=$(awk -F@ '{print $2}' <<<$1)
+sshHost=127.0.0.1
 
 ssh -p $SSH_PORT $1 "killall vboxwebsrv"
 ssh -p $SSH_PORT -L 0.0.0.0:18083:$sshHost:$PORT $1 "killall vboxwebsrv; vboxwebsrv -p $PORT -A null -H $sshHost"


### PR DESCRIPTION
The vboxwerbsrv should be bound to localhost. As we use an SSH-Tunnel anyway to connect to it. 
Doing so you won't expose the vboxwebsrv publicly and protect the service against outside access. 
Maybe we could use a extra variable for the host the service is bound to, if someone needs it open for other reasons.